### PR TITLE
CC-16934: Add Glue support in Unzer ECO module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ UnzerApi module provides Unzer API HTTP communication layer.
 composer require spryker-eco/unzer-api
 ```
 ## Documentation
-[Documentation](https://docs.spryker.com/industry_partners/payment/unzer-api/unzer-api-details.htm)
+[Documentation](https://docs.spryker.com/docs/pbc/all/payment/unzer/unzer.html)

--- a/src/SprykerEco/Shared/UnzerApi/Transfer/unzer_api.transfer.xml
+++ b/src/SprykerEco/Shared/UnzerApi/Transfer/unzer_api.transfer.xml
@@ -101,6 +101,7 @@
         <property name="returnUrl" type="string"/>
         <property name="customerId" type="string"/>
         <property name="typeId" type="string"/>
+        <property name="orderId" type="string"/>
     </transfer>
 
     <transfer name="UnzerApiMarketplaceAuthorizeRequest">
@@ -260,6 +261,7 @@
         <property name="uniqueId" type="string"/>
         <property name="shortId" type="string"/>
         <property name="participantId" type="string"/>
+        <property name="orderId" type="string"/>
     </transfer>
 
     <transfer name="UnzerApiGetPaymentResponse">
@@ -313,6 +315,7 @@
         <property name="uniqueId" type="string"/>
         <property name="shortId" type="string"/>
         <property name="participantId" type="string"/>
+        <property name="orderId" type="string"/>
     </transfer>
 
     <transfer name="UnzerApiChargeResponse">

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/AuthorizableChargeRequestConverter.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/AuthorizableChargeRequestConverter.php
@@ -15,7 +15,7 @@ class AuthorizableChargeRequestConverter implements UnzerApiRequestConverterInte
     /**
      * @param \Generated\Shared\Transfer\UnzerApiRequestTransfer $unzerApiRequestTransfer
      *
-     * @return array<string, string>
+     * @return array<string, string|null>
      */
     public function convertUnzerApiRequestTransferToArray(UnzerApiRequestTransfer $unzerApiRequestTransfer): array
     {

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/AuthorizableChargeRequestConverter.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/AuthorizableChargeRequestConverter.php
@@ -23,6 +23,7 @@ class AuthorizableChargeRequestConverter implements UnzerApiRequestConverterInte
 
         return [
             UnzerApiRequestConstants::PARAM_AMOUNT => (string)$unzerApiChargeRequestTransfer->getAmount(),
+            UnzerApiRequestConstants::PARAM_ORDER_ID => $unzerApiChargeRequestTransfer->getOrderId(),
         ];
     }
 }

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/AuthorizeRequestConverter.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/AuthorizeRequestConverter.php
@@ -25,6 +25,7 @@ class AuthorizeRequestConverter implements UnzerApiRequestConverterInterface
             UnzerApiRequestConstants::PARAM_AMOUNT => (string)$unzerApiAuthorizeRequestTransfer->getAmount(),
             UnzerApiRequestConstants::PARAM_CURRENCY => $unzerApiAuthorizeRequestTransfer->getCurrency(),
             UnzerApiRequestConstants::PARAM_RETURN_URL => $unzerApiAuthorizeRequestTransfer->getReturnUrl(),
+            UnzerApiRequestConstants::PARAM_ORDER_ID => $unzerApiAuthorizeRequestTransfer->getOrderId(),
             UnzerApiRequestConstants::PARAM_RESOURCES => [
                 UnzerApiRequestConstants::PARAM_CUSTOMER_ID => $unzerApiAuthorizeRequestTransfer->getCustomerId(),
                 UnzerApiRequestConstants::PARAM_TYPE_ID => $unzerApiAuthorizeRequestTransfer->getTypeId(),

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/ChargeRequestConverter.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/ChargeRequestConverter.php
@@ -25,6 +25,7 @@ class ChargeRequestConverter implements UnzerApiRequestConverterInterface
             UnzerApiRequestConstants::PARAM_AMOUNT => (string)$unzerApiChargeRequestTransfer->getAmount(),
             UnzerApiRequestConstants::PARAM_CURRENCY => $unzerApiChargeRequestTransfer->getCurrency(),
             UnzerApiRequestConstants::PARAM_RETURN_URL => $unzerApiChargeRequestTransfer->getReturnUrl(),
+            UnzerApiRequestConstants::PARAM_ORDER_ID => $unzerApiChargeRequestTransfer->getOrderId(),
             UnzerApiRequestConstants::PARAM_RESOURCES => [
                 UnzerApiRequestConstants::PARAM_TYPE_ID => $unzerApiChargeRequestTransfer->getTypeId(),
             ],

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/MarketplaceAuthorizeRequestConverter.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Request/Converter/MarketplaceAuthorizeRequestConverter.php
@@ -25,6 +25,7 @@ class MarketplaceAuthorizeRequestConverter implements UnzerApiRequestConverterIn
             UnzerApiRequestConstants::PARAM_AMOUNT => (string)$unzerApiMarketplaceAuthorizeRequestTransfer->getAmount(),
             UnzerApiRequestConstants::PARAM_CURRENCY => $unzerApiMarketplaceAuthorizeRequestTransfer->getCurrency(),
             UnzerApiRequestConstants::PARAM_RETURN_URL => $unzerApiMarketplaceAuthorizeRequestTransfer->getReturnUrl(),
+            UnzerApiRequestConstants::PARAM_ORDER_ID => $unzerApiMarketplaceAuthorizeRequestTransfer->getOrderId(),
             UnzerApiRequestConstants::PARAM_RESOURCES => [
                 UnzerApiRequestConstants::PARAM_CUSTOMER_ID => $unzerApiMarketplaceAuthorizeRequestTransfer->getCustomerId(),
                 UnzerApiRequestConstants::PARAM_TYPE_ID => $unzerApiMarketplaceAuthorizeRequestTransfer->getTypeId(),

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/AuthorizeResponseMapper.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/AuthorizeResponseMapper.php
@@ -35,7 +35,8 @@ class AuthorizeResponseMapper implements UnzerApiResponseMapperInterface
             ->setCurrency($responseData[UnzerApiRequestConstants::PARAM_CURRENCY] ?? null)
             ->setReturnUrl($responseData[UnzerApiRequestConstants::PARAM_RETURN_URL] ?? null)
             ->setDate($responseData[UnzerApiRequestConstants::PARAM_DATE] ?? null)
-            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null);
+            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null)
+            ->setOrderId($responseData[UnzerApiRequestConstants::PARAM_ORDER_ID] ?? null);
 
         $unzerApiAuthorizeResponseTransfer = $this->mapMessageDataToUnzerApiAuthorizeResponseTransfer(
             $responseData[UnzerApiRequestConstants::PARAM_MESSAGE] ?? [],

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/ChargeResponseMapper.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/ChargeResponseMapper.php
@@ -34,7 +34,8 @@ class ChargeResponseMapper implements UnzerApiResponseMapperInterface
             ->setCurrency($responseData[UnzerApiRequestConstants::PARAM_CURRENCY] ?? null)
             ->setReturnUrl($responseData[UnzerApiRequestConstants::PARAM_RETURN_URL] ?? null)
             ->setDate($responseData[UnzerApiRequestConstants::PARAM_DATE] ?? null)
-            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null);
+            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null)
+            ->setOrderId($responseData[UnzerApiRequestConstants::PARAM_ORDER_ID] ?? null);
 
         $unzerApiChargeResponseTransfer = $this->mapResourcesDataToUnzerApiResponseTransfer(
             $responseData[UnzerApiRequestConstants::PARAM_RESOURCES],

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/CreditCardChargeResponseMapper.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/CreditCardChargeResponseMapper.php
@@ -32,7 +32,8 @@ class CreditCardChargeResponseMapper implements UnzerApiResponseMapperInterface
             ->setAmount($responseData[UnzerApiRequestConstants::PARAM_AMOUNT] ?? null)
             ->setCurrency($responseData[UnzerApiRequestConstants::PARAM_CURRENCY] ?? null)
             ->setDate($responseData[UnzerApiRequestConstants::PARAM_DATE] ?? null)
-            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null);
+            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null)
+            ->setOrderId($responseData[UnzerApiRequestConstants::PARAM_ORDER_ID] ?? null);
 
         $unzerApiChargeResponseTransfer = $this->mapResourcesDataToUnzerApiChargeResponseTransfer(
             $responseData[UnzerApiRequestConstants::PARAM_RESOURCES],

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/MarketplaceAuthorizeResponseMapper.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/MarketplaceAuthorizeResponseMapper.php
@@ -35,7 +35,8 @@ class MarketplaceAuthorizeResponseMapper implements UnzerApiResponseMapperInterf
             ->setCurrency($responseData[UnzerApiRequestConstants::PARAM_CURRENCY] ?? null)
             ->setReturnUrl($responseData[UnzerApiRequestConstants::PARAM_RETURN_URL] ?? null)
             ->setDate($responseData[UnzerApiRequestConstants::PARAM_DATE] ?? null)
-            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null);
+            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null)
+            ->setOrderId($responseData[UnzerApiRequestConstants::PARAM_ORDER_ID] ?? null);
 
         $unzerApiMarketplaceAuthorizeResponseTransfer = $this->mapMessageDataToResponseTransfer(
             $responseData[UnzerApiRequestConstants::PARAM_MESSAGE] ?? [],

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/MarketplaceRefundResponseMapper.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/MarketplaceRefundResponseMapper.php
@@ -34,7 +34,8 @@ class MarketplaceRefundResponseMapper implements UnzerApiResponseMapperInterface
             ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null)
             ->setDate($responseData[UnzerApiRequestConstants::PARAM_DATE] ?? null)
             ->setCard3ds($responseData[UnzerApiRequestConstants::PARAM_CARD3DS] ?? null)
-            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null);
+            ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null)
+            ->setOrderId($responseData[UnzerApiRequestConstants::PARAM_ORDER_ID] ?? null);
 
         $unzerApiMarketplaceRefundResponseTransfer = $this->mapResourceDataToUnzerApiMarketplaceRefundResponseTransfer(
             $responseData[UnzerApiRequestConstants::PARAM_RESOURCES] ?? [],

--- a/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/RefundResponseMapper.php
+++ b/src/SprykerEco/Zed/UnzerApi/Business/Api/Response/Mapper/RefundResponseMapper.php
@@ -32,7 +32,8 @@ class RefundResponseMapper implements UnzerApiResponseMapperInterface
             ->setAmount($responseData[UnzerApiRequestConstants::PARAM_AMOUNT] ?? null)
             ->setCurrency($responseData[UnzerApiRequestConstants::PARAM_CURRENCY] ?? null)
             ->setPaymentReference($responseData[UnzerApiRequestConstants::PARAM_PAYMENT_REFERENCE] ?? null)
-            ->setDate($responseData[UnzerApiRequestConstants::PARAM_DATE] ?? null);
+            ->setDate($responseData[UnzerApiRequestConstants::PARAM_DATE] ?? null)
+            ->setOrderId($responseData[UnzerApiRequestConstants::PARAM_ORDER_ID] ?? null);
 
         $unzerApiRefundResponseTransfer = $this->mapResourcesToUnzerApiRefundResponseTransfer(
             $responseData[UnzerApiRequestConstants::PARAM_RESOURCES] ?? [],


### PR DESCRIPTION
- Developer(s): @michbeck

- Ticket: https://spryker.atlassian.net/browse/CC-16934

- Release Group: https://release.spryker.com/release-groups/view/4251

- PR Overview: https://release.spryker.com/release/pull-request-eco/UnzerApi/16

- merge: squash

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   UnzerApi              | minor                 |                       |

-----------------------------------------

#### Module UnzerApi

##### Change log

Improvements

- Introduced `UnzerApiAuthorizeRequestTransfer.orderId` transfer field.
- Introduced `UnzerApiAuthorizeResponseTransfer.orderId` transfer field.
- Introduced `UnzerApiMarketplaceAuthorizeResponseTransfer.orderId` transfer field.
- Adjusted `UnzerApiFacade::performChargeApiCall()` so it maps related orderId to request and from response data.
- Adjusted `UnzerApiFacade::performMarketplaceAuthorizeApiCall()` so it maps related orderId to request and from response data.
- Adjusted `UnzerApiFacade::performAuthorizeApiCall()` so it maps related orderId to request and from response data.
- Adjusted `UnzerApiFacade::performAuthorizableChargeApiCall()` so it maps related orderId to request and from response data.
- Adjusted `UnzerApiFacade::performMarketplaceRefundApiCall()` so it maps related orderId to request and from response data.
- Adjusted `UnzerApiFacade::performMarketplaceRefundApiCall()` so it maps related orderId to request and from response data.